### PR TITLE
Fix resetting selected item when pressing tab

### DIFF
--- a/src/popup/screens/home_screen/index.jsx
+++ b/src/popup/screens/home_screen/index.jsx
@@ -56,6 +56,10 @@ export default function HomeScreen() {
     }
   }, [selectedIndex, totalItems]);
 
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [searchQuery]);
+
   const execute = (url) => {
     dispatch(executeBookmarklet(url));
     window.close();
@@ -108,7 +112,6 @@ export default function HomeScreen() {
       }
     }
 
-    setSelectedIndex(0);
     setSearchQuery(searchInputRef.current.value);
   };
 


### PR DESCRIPTION
## Problem
Changing focus would reset the selected item to the top of the list

## Solution
- Only reset the selected item to the top when the search query changes instead of when input changes