### PR TITLE
Fix uncaught error when trying to match on bookmarks without `url` param

### DIFF
--- a/src/popup/store/actions/bookmarklets.js
+++ b/src/popup/store/actions/bookmarklets.js
@@ -39,12 +39,8 @@ export function fetchAllBookmarklets() {
         query: 'javascript:'
       },
       (results) => {
-        const resultsWithTitlesAndUrls = results.filter((result) => {
-          return result.title && result.url;
-        });
-
-        const filteredResults = resultsWithTitlesAndUrls.filter((result) => {
-          return result.url.match(/^javascript\:/);
+        const filteredResults = results.filter((result) => {
+          return result.url && result.url.match(/^javascript\:/);
         });
 
         dispatch(setBookmarklets(filteredResults));

--- a/src/popup/store/actions/bookmarklets.js
+++ b/src/popup/store/actions/bookmarklets.js
@@ -34,10 +34,16 @@ export function fetchAllBookmarklets() {
   return (dispatch, getState, { browser }) => {
     browser.bookmarks.search(
       {
+        // Use query because it's fuzzy, searching by URL only returns
+        // exact macthes.
         query: 'javascript:'
       },
       (results) => {
-        const filteredResults = results.filter((result) => {
+        const resultsWithTitlesAndUrls = results.filter((result) => {
+          return result.title && result.url;
+        });
+
+        const filteredResults = resultsWithTitlesAndUrls.filter((result) => {
           return result.url.match(/^javascript\:/);
         });
 


### PR DESCRIPTION
## Problem
When someone has a folder with the word "javascript" in the name the popup throws an error which breaks the app.

The app breaks because it will try to perform a string `match` on a undefined property `url`. Folders don't have URLs!!

## Solution
- Filter for bookmarks that only have  `url`