### PR TITLE
Change <CodeEditor /> component to use CodeMirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,6 +2254,11 @@
         "q": "^1.1.2"
       }
     },
+    "codemirror": {
+      "version": "5.52.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.2.tgz",
+      "integrity": "sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -6257,6 +6262,11 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-codemirror2": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.1.0.tgz",
+      "integrity": "sha512-Rel0QbPnCTjHxgZYt6TkGw4icSZXNyONHb72a+1wWA+PlYJIvzFAv4pZlDPG0rpKpKmy4kSUlkoWgneH7w3A0g=="
     },
     "react-dom": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "codemirror": "^5.52.2",
     "fuse.js": "^3.6.1",
     "prettier": "^2.0.1",
     "react": "^16.13.1",
+    "react-codemirror2": "^7.1.0",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",

--- a/src/popup/components/code_editor/code_editor.css
+++ b/src/popup/components/code_editor/code_editor.css
@@ -3,21 +3,11 @@
   height: 100%;
 }
 
-.code-editor__input {
+.code-editor .CodeMirror {
   background-color: var(--input-normal-background);
-  color: var(--input-normal-color);
-  border-color: var(--input-normal-border-color);
+  border: 1px solid var(--input-normal-border-color);
   font-size: var(--button-font-size);
-  border-width: 1px;
-  border-style: solid;
   border-radius: 3px;
-  width: 100%;
-  padding: 8px;
-  font-family: monospace;
-  outline: none;
-  width: 100%;
-  height: 100%;
-  resize: none;
 }
 
 .code-editor__input:focus {

--- a/src/popup/components/code_editor/code_editor.css
+++ b/src/popup/components/code_editor/code_editor.css
@@ -10,11 +10,7 @@
   border-radius: 3px;
 }
 
-.code-editor__input:focus {
+.code-editor .CodeMirror-focused {
   border-color: var(--global-focus-border-color);
   box-shadow: var(--global-focus-box-shadow);
-}
-
-.code-editor__input::placeholder {
-  color: var(--input-placeholder-color);
 }

--- a/src/popup/components/code_editor/code_editor.css
+++ b/src/popup/components/code_editor/code_editor.css
@@ -12,6 +12,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
+  font-size: 14px;
 }
 
 .code-editor .CodeMirror-focused {

--- a/src/popup/components/code_editor/code_editor.css
+++ b/src/popup/components/code_editor/code_editor.css
@@ -1,6 +1,7 @@
 .code-editor {
   width: 100%;
   height: 100%;
+  position: relative;
 }
 
 .code-editor .CodeMirror {
@@ -8,6 +9,9 @@
   border: 1px solid var(--input-normal-border-color);
   font-size: var(--button-font-size);
   border-radius: 3px;
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }
 
 .code-editor .CodeMirror-focused {

--- a/src/popup/components/code_editor/index.jsx
+++ b/src/popup/components/code_editor/index.jsx
@@ -17,6 +17,34 @@ const CODE_MIRROR_OPTIONS = {
 
 export default function CodeEditor({ defaultValue, onChange = () => {} }) {
   const [value, setValue] = useState(defaultValue);
+  const [options, setOptions] = useState(CODE_MIRROR_OPTIONS);
+
+  const handleOnColorSchemeChange = (evt) => {
+    const isDarkTheme = evt.matches;
+
+    if (isDarkTheme) {
+      setOptions({
+        ...CODE_MIRROR_OPTIONS,
+        theme: 'material'
+      });
+    } else {
+      setOptions({
+        ...CODE_MIRROR_OPTIONS,
+        theme: 'default'
+      });
+    }
+  };
+
+  useEffect(() => {
+    const schemeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    handleOnColorSchemeChange(schemeMediaQuery);
+    schemeMediaQuery.addListener(handleOnColorSchemeChange);
+
+    return () => {
+      schemeMediaQuery.removeListener(handleOnColorSchemeChange);
+    }
+  }, []);
 
   // When `defaultValue` prop changes, change the local state with that value.
   useEffect(() => {
@@ -35,7 +63,7 @@ export default function CodeEditor({ defaultValue, onChange = () => {} }) {
         onBeforeChange={(editor, data, value) => {
           handleOnChange(value);
         }}
-        options={CODE_MIRROR_OPTIONS}
+        options={options}
       />
     </div>
   );

--- a/src/popup/components/code_editor/index.jsx
+++ b/src/popup/components/code_editor/index.jsx
@@ -21,18 +21,12 @@ export default function CodeEditor({ defaultValue, onChange = () => {} }) {
 
   const handleOnColorSchemeChange = (evt) => {
     const isDarkTheme = evt.matches;
+    const theme = isDarkTheme ? 'material' : 'default';
 
-    if (isDarkTheme) {
-      setOptions({
-        ...CODE_MIRROR_OPTIONS,
-        theme: 'material'
-      });
-    } else {
-      setOptions({
-        ...CODE_MIRROR_OPTIONS,
-        theme: 'default'
-      });
-    }
+    setOptions({
+      ...CODE_MIRROR_OPTIONS,
+      theme
+    });
   };
 
   useEffect(() => {

--- a/src/popup/components/code_editor/index.jsx
+++ b/src/popup/components/code_editor/index.jsx
@@ -1,6 +1,19 @@
 import React, { useState, useEffect } from 'react';
+import { Controlled as CodeMirror } from 'react-codemirror2';
+
+require('codemirror/mode/javascript/javascript');
+require('codemirror/addon/edit/closebrackets');
 
 import './code_editor.css';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/theme/material.css';
+
+const CODE_MIRROR_OPTIONS = {
+  tabSize: 2,
+  lineNumbers: true,
+  autoCloseBrackets: true,
+  theme: 'default'
+};
 
 export default function CodeEditor({ defaultValue, onChange = () => {} }) {
   const [value, setValue] = useState(defaultValue);
@@ -10,18 +23,19 @@ export default function CodeEditor({ defaultValue, onChange = () => {} }) {
     setValue(defaultValue);
   }, [defaultValue]);
 
-  const handleOnChange = (evt) => {
-    setValue(evt.target.value);
-    onChange(evt.target.value);
+  const handleOnChange = (value) => {
+    setValue(value);
+    onChange(value);
   };
 
   return (
     <div className="code-editor">
-      <textarea
-        className="code-editor__input"
-        onChange={handleOnChange}
+      <CodeMirror
         value={value}
-        spellCheck={false}
+        onBeforeChange={(editor, data, value) => {
+          handleOnChange(value);
+        }}
+        options={CODE_MIRROR_OPTIONS}
       />
     </div>
   );

--- a/src/popup/screens/editor_screen/editor_screen.css
+++ b/src/popup/screens/editor_screen/editor_screen.css
@@ -18,7 +18,6 @@
 
 .editor-screen__section--full {
   height: 100%;
-  overflow: scroll;
 }
 
 .editor-screen__section--space-between {

--- a/src/popup/screens/editor_screen/editor_screen.css
+++ b/src/popup/screens/editor_screen/editor_screen.css
@@ -18,6 +18,7 @@
 
 .editor-screen__section--full {
   height: 100%;
+  overflow: scroll;
 }
 
 .editor-screen__section--space-between {

--- a/src/popup/store/actions/ui.js
+++ b/src/popup/store/actions/ui.js
@@ -1,5 +1,5 @@
-const EDITOR_WINDOW_WIDTH = 500;
-const EDITOR_WINDOW_HEIGHT = 450;
+const EDITOR_WINDOW_WIDTH = 700;
+const EDITOR_WINDOW_HEIGHT = 520;
 
 export function navigateTo(url) {
   return (dispatch, getState, { browser }) => {


### PR DESCRIPTION
## Summary
The `<CodeEditor />` component needed something better than `<textarea />` for editing scripts. But not a full blown IDE.

I've tried [`monaco-editor`](https://github.com/anthonyec/powerlets/compare/monoco-editor), [`ace-editor`](https://github.com/anthonyec/powerlets/compare/ace-editor) and [`simple-code-editor`](https://github.com/anthonyec/powerlets/compare/simple-code-editor). All have major draw backs. CodeMirror seems to be the most robust, easiest to setup and smallest in file size.

![image](https://user-images.githubusercontent.com/1451668/78717438-7eb21f00-7918-11ea-9664-aeea14c23c5f.png)
![image](https://user-images.githubusercontent.com/1451668/78717381-693cf500-7918-11ea-8bd5-6804e68832b9.png)

## Changes
- Add CodeMirror editor via [react-codemirror2](https://www.npmjs.com/package/react-codemirror2)
- Change editor window size to fit 80 columns
- Change editor theme based of `prefers-color-scheme`
- Add `closebrackets` addon to automatically close brackets
